### PR TITLE
Add missing reference to .Business

### DIFF
--- a/src/03/Start_Here/WarehouseManagementSystem/WarehouseManagementSystem.Windows/WarehouseManagementSystem.Windows.csproj
+++ b/src/03/Start_Here/WarehouseManagementSystem/WarehouseManagementSystem.Windows/WarehouseManagementSystem.Windows.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\WarehouseManagementSystem.Business\WarehouseManagementSystem.Business.csproj" />
+  </ItemGroup>
+   
+  <ItemGroup>
     <None Update="orders.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Following lesson 04 of part 03 "Why unsubscribing is important". Uses the OrderProcessor class in the tutorial but the reference is missing from the source project.